### PR TITLE
Improve change detection

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -3,6 +3,7 @@
 <head>
 
 <title>splendid textchange demo</title>
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
 <style>
 textarea {
@@ -17,7 +18,7 @@ textarea {
 Input: <input type="text" id="input"><br>
 <textarea id="log" readonly></textarea>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="jquery.splendid.textchange.js"></script>
 <script>
 $("#input").on("textchange", function() {

--- a/demo.html
+++ b/demo.html
@@ -16,8 +16,8 @@ textarea {
 <body>
 
 Input:
-<input type="text" class="in" autofocus><br>
-<textarea class="in"></textarea><br>
+<input type="text" class="in" id="single" autofocus><br>
+<textarea class="in" id="multi"></textarea><br>
 <textarea id="log" readonly></textarea>
 
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
@@ -26,14 +26,12 @@ Input:
 var log = $("#log")[0];
 
 $(".in").on("textchange", function() {
-    var input = this;
+    var input = this, value = input.value;
 
-    window.setTimeout(function () {
-        input.value = input.value;
+    input.value = value;
 
-        log.value = log.value.concat(input.tagName, ": ", input.value, "\n");
-        log.scrollTop = log.scrollHeight;
-    }, 0);
+    log.value = log.value.concat(input.tagName, ": ", value, "\n");
+    log.scrollTop = log.scrollHeight;
 });
 </script>
 

--- a/demo.html
+++ b/demo.html
@@ -15,7 +15,7 @@ textarea {
 </head>
 <body>
 
-Input: <input type="text" id="input"><br>
+Input: <input type="text" id="input" autofocus><br>
 <textarea id="log" readonly></textarea>
 
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>

--- a/demo.html
+++ b/demo.html
@@ -15,17 +15,25 @@ textarea {
 </head>
 <body>
 
-Input: <input type="text" id="input" autofocus><br>
+Input:
+<input type="text" class="in" autofocus><br>
+<textarea class="in"></textarea><br>
 <textarea id="log" readonly></textarea>
 
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="jquery.splendid.textchange.js"></script>
 <script>
-$("#input").on("textchange", function() {
-    var value = this.value;
-    $("#log").val(function(i, oldLog) {
-        return oldLog + "textchange, value: " + value + "\n";
-    });
+var log = $("#log")[0];
+
+$(".in").on("textchange", function() {
+    var input = this;
+
+    window.setTimeout(function () {
+        input.value = input.value;
+
+        log.value = log.value.concat(input.tagName, ": ", input.value, "\n");
+        log.scrollTop = log.scrollHeight;
+    }, 0);
 });
 </script>
 

--- a/demo.html
+++ b/demo.html
@@ -20,7 +20,7 @@ Input:
 <textarea class="in" id="multi"></textarea><br>
 <textarea id="log" readonly></textarea>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
 <script src="jquery.splendid.textchange.js"></script>
 <script>
 var log = $("#log")[0];

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -8,7 +8,7 @@
 (function($) {
 
 var testNode = document.createElement("input");
-var isInputSupported = "oninput" in testNode && 
+var isInputSupported = "oninput" in testNode &&
     (!("documentMode" in document) || document.documentMode > 9);
 
 var hasInputCapabilities = function(elem) {
@@ -49,7 +49,7 @@ var startWatching = function(target) {
     activeElement = target;
     activeElementValue = target.value;
     activeElementValueProp = Object.getOwnPropertyDescriptor(
-            target.constructor.prototype, "value");
+        target.constructor.prototype, "value");
 
     Object.defineProperty(activeElement, "value", newValueProp);
     activeElement.attachEvent("onpropertychange", handlePropertyChange);
@@ -60,15 +60,15 @@ var startWatching = function(target) {
  * element, if any exists.
  */
 var stopWatching = function() {
-  if (!activeElement) return;
+    if (!activeElement) return;
 
-  // delete restores the original property definition
-  delete activeElement.value;
-  activeElement.detachEvent("onpropertychange", handlePropertyChange);
+    // delete restores the original property definition
+    delete activeElement.value;
+    activeElement.detachEvent("onpropertychange", handlePropertyChange);
 
-  activeElement = null;
-  activeElementValue = null;
-  activeElementValueProp = null;
+    activeElement = null;
+    activeElementValue = null;
+    activeElementValueProp = null;
 };
 
 /**

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -131,9 +131,7 @@ if (isInputSupported) {
             }
         })
 
-        .on("focusout", function() {
-            stopWatching();
-        })
+        .on("focusout", stopWatching)
 
         .on("selectionchange keyup keydown", function() {
             // On the selectionchange event, e.target is just document which

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -1,5 +1,5 @@
 /**
- * jQuery "splendid textchange" plugin
+ * jQuery "splendid textchange" plugin, v1.2 alpha1
  * http://benalpert.com/2013/06/18/a-near-perfect-oninput-shim-for-ie-8-and-9.html
  *
  * (c) 2013 Ben Alpert, released under the MIT license

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -28,7 +28,7 @@
 
     // ********* OLD IE (9 and older) *********
 
-    var queueActiveElementForNotification = null;
+    var queueEventTargetForNotification = null;
     var activeElement = null;
     var notificationQueue = [];
     var watchedEvents = "keyup keydown";
@@ -82,10 +82,10 @@
 
                 // subscribe once, never unsuncribe
                 $(target)
-                    .on("propertychange", queueActiveElementForNotification)
+                    .on("propertychange", queueEventTargetForNotification)
                     .on("dragend", function (e) {
                         window.setTimeout(function () {
-                            queueActiveElementForNotification(e);
+                            queueEventTargetForNotification(e);
                         }, 0);
                     });
             }
@@ -116,7 +116,7 @@
 
     // If target element of the specified event has not yet been
     // queued for notification, queue it now.
-    queueActiveElementForNotification = function queueActiveElementForNotification(e) {
+    queueEventTargetForNotification = function queueEventTargetForNotification(e) {
         var target = e.target;
         installValueExtensionsOn(target);
 
@@ -141,14 +141,14 @@
     // Mark the specified target element as "active" and add event listeners to it.
     function startWatching(target) {
         activeElement = target;
-        $(activeElement).on(watchedEvents, queueActiveElementForNotification);
+        $(activeElement).on(watchedEvents, queueEventTargetForNotification);
     }
 
 
     // Remove the event listeners from the "active" element and set "active" to null.
     function stopWatching() {
         if (activeElement) {
-            $(activeElement).off(watchedEvents, queueActiveElementForNotification);
+            $(activeElement).off(watchedEvents, queueEventTargetForNotification);
             activeElement = null;
         }
     }
@@ -178,7 +178,7 @@
 
         .on("focusout", stopWatching)
 
-        .on("input", queueActiveElementForNotification)
+        .on("input", queueEventTargetForNotification)
 
         .on("selectionchange", function onSplendidSelectionChange(e) {
             // IE sets "e.target" to "document" in "onselectionchange"
@@ -190,7 +190,7 @@
                     var p = r.parentElement();
                     if (p) {
                         e.target = p;
-                        queueActiveElementForNotification(e);
+                        queueEventTargetForNotification(e);
                     }
                 }
             }

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -62,7 +62,6 @@
     function installValueExtensionsOn(target) {
         if (!target.valueExtensions) { // we haven't installed extensions yet (or "target" is not an input-capable element)
             if (hasInputCapabilities(target)) {
-                if (window.console) { window.console.log("Installing value extensions on " + target.id); }
                 target.valueExtensions = {
                     current: null // not setting "current" initially (to "target.value") allows drag & drop operations (from outside the control) to send change notifications
                 };
@@ -83,8 +82,9 @@
                     });
                 }
 
+                // subscribe once, never unsuncribe
                 $(target)
-                    .on("propertychange", queueActiveElementForNotification) // subscribe once, never unsuncribe
+                    .on("propertychange", queueActiveElementForNotification)
                     .on("dragend", function (e) {
                         window.setTimeout(function () {
                             queueActiveElementForNotification(e);
@@ -96,12 +96,10 @@
 
     /**
      * (For old IE.) For each queued element: if value of the element is
-     * different from current value, update the current value and trigger
+     * different from the current value, update the current value and trigger
      * "textchange" event on that element.
      */
     function processNotificationQueue() {
-        if (window.console) { window.console.log("Processing notifications: " + notificationQueue.length); }
-
         // remember the current notification queue (for processing)
         // + create a new queue so that if "textchange" event handlers
         // cause new notification requests to be queued, they will be
@@ -114,7 +112,6 @@
             target = q[i];
             targetValue = target.value;
             if (target.valueExtensions.current !== targetValue) {
-                if (window.console) { window.console.log("Before textchange for " + target.id + ": \"" + target.valueExtensions.current + "\", \"" + targetValue + "\""); }
                 target.valueExtensions.current = targetValue;
                 $(target).trigger("textchange");
             }
@@ -126,15 +123,10 @@
      * notification, queue it now.
      */
     queueActiveElementForNotification = function queueActiveElementForNotification(e) {
-        if (window.console) { window.console.log("Queue: " + e.type + ", " + e.target.id + ", \"" + e.target.value + "\""); }
-
         var target = e.target;
-        if (target !== activeElement) {
-            installValueExtensionsOn(target);
-        }
+        installValueExtensionsOn(target);
 
         if (target.valueExtensions && target.valueExtensions.current !== target.value) {
-            if (window.console) { window.console.log("Queue accepted"); }
             var i, l;
             for (i = 0, l = notificationQueue.length; i < l; i += 1) {
                 if (notificationQueue[i] === target) {
@@ -156,7 +148,6 @@
      * tracked element and adds event listeners to it.
      */
     function startWatching(target) {
-        if (window.console) { window.console.log("Start watching " + target.id); }
         activeElement = target;
         $(activeElement).on(watchedEvents, queueActiveElementForNotification);
     }
@@ -167,7 +158,6 @@
      */
     function stopWatching() {
         if (activeElement) {
-            if (window.console) { window.console.log("Stop watching " + activeElement.id); }
             $(activeElement).off(watchedEvents, queueActiveElementForNotification);
             activeElement = null;
         }

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -83,7 +83,13 @@
                     });
                 }
 
-                $(target).on("propertychange", queueActiveElementForNotification); // subscribe once, never unsuncribe
+                $(target)
+                    .on("propertychange", queueActiveElementForNotification) // subscribe once, never unsuncribe
+                    .on("dragend", function (e) {
+                        window.setTimeout(function () {
+                            queueActiveElementForNotification(e);
+                        }, 0);
+                    });
             }
         }
     }

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -13,7 +13,7 @@
 
 var testNode = document.createElement("input");
 var isInputSupported = "oninput" in testNode &&
-    (!("documentMode" in document) || document.documentMode > 9);
+    ((document.documentMode || 100) > 9);
 
 var hasInputCapabilities = function(elem) {
     // The HTML5 spec lists many more types than `text` and `password` on

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -12,8 +12,8 @@
 "use strict";
 
 var testNode = document.createElement("input");
-var isInputSupported = "oninput" in testNode &&
-    ((document.documentMode || 100) > 9);
+var isInputSupported = (testNode.oninput !== undefined &&
+    ((document.documentMode || 100) > 9));
 
 var hasInputCapabilities = function(elem) {
     // The HTML5 spec lists many more types than `text` and `password` on

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -68,7 +68,7 @@ var startWatching = function(target) {
     activeElement = target;
     activeElementValue = target.value;
 
-    if (target.constructor && target.constructor.prototype) { // target.constructor is null in quirks mode
+    if (target.constructor && target.constructor.prototype) { // target.constructor is undefined in quirks mode
         activeElementValueProp = Object.getOwnPropertyDescriptor(
             target.constructor.prototype, "value");
         Object.defineProperty(activeElement, "value", newValueProp);

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -169,7 +169,7 @@
     // value is changed from JS so we redefine a setter for `.value`
     // that allows us to ignore those changes (in "installValueExtensionsOn").
     $(document)
-        .on("focusin", function onSpendidFocusin(e) {
+        .on("focusin", function onSplendidFocusin(e) {
             // stopWatching() should be a noop here but we call it just in
             // case we missed a blur event somehow.
             stopWatching();

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -38,8 +38,6 @@
         // Catching keyup usually gets it and catching keydown lets us fire
         // an event for the first keystroke if user does a key repeat
         // (it'll be a little delayed: right before the second keystroke).
-        // Other input methods (e.g., paste) seem to fire selectionchange
-        // normally.
 
 
     // Return true if the specified element can generate
@@ -80,11 +78,11 @@
                     });
                 }
 
-                // subscribe once, never unsuncribe
+                // subscribe once, never unsubcribe
                 $(target)
                     .on("propertychange", queueEventTargetForNotification)
-                    .on("dragend", function (e) {
-                        window.setTimeout(function () {
+                    .on("dragend", function onSplendidDragend(e) {
+                        window.setTimeout(function onSplendidDragendDelayed() {
                             queueEventTargetForNotification(e);
                         }, 0);
                     });
@@ -154,22 +152,23 @@
     }
 
 
+    // In IE 8, we can capture almost all .value changes by adding a
+    // propertychange handler (in "installValueExtensionsOn").
+    //
+    // In IE 9, propertychange/input fires for most input events but is buggy
+    // and doesn't fire when text is deleted, but conveniently,
+    // "selectionchange" appears to fire in all of the remaining cases so
+    // we catch those.
+    //
+    // In either case, we don't want to call the event handler if the
+    // value is changed from JS so we redefine a setter for `.value`
+    // that allows us to ignore those changes (in "installValueExtensionsOn").
     $(document)
-        .on("focusin", function (e) {
+        .on("focusin", function onSpendidFocusin(e) {
             // stopWatching() should be a noop here but we call it just in
             // case we missed a blur event somehow.
             stopWatching();
 
-            // In IE 8, we can capture almost all .value changes by adding a
-            // propertychange handler.
-            // In IE 9, propertychange/input fires for most input events but is buggy
-            // and doesn't fire when text is deleted, but conveniently,
-            // selectionchange appears to fire in all of the remaining cases so
-            // we catch those and forward the event if the value has changed.
-            // In either case, we don't want to call the event handler if the
-            // value is changed from JS so we redefine a setter for `.value`
-            // that updates our activeElement.valueExtensions.current variable,
-            // allowing us to ignore those changes.
             installValueExtensionsOn(e.target);
             if (e.target.valueExtensions) {
                 startWatching(e.target);

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -5,7 +5,11 @@
  * (c) 2013 Ben Alpert, released under the MIT license
  */
 
+/*global jQuery: false */
+/*jslint browser: true, white: true, vars: true */
+
 (function($) {
+"use strict";
 
 var testNode = document.createElement("input");
 var isInputSupported = "oninput" in testNode &&
@@ -41,6 +45,20 @@ var newValueProp =  {
 };
 
 /**
+ * (For old IE.) Handles a propertychange event, sending a textChange event if
+ * the value of the active element has changed.
+ */
+var handlePropertyChange = function(nativeEvent) {
+    if (nativeEvent.propertyName !== "value") { return; }
+
+    var value = nativeEvent.srcElement.value;
+    if (value === activeElementValue) { return; }
+    activeElementValue = value;
+
+    $(activeElement).trigger("textchange");
+};
+
+/**
  * (For old IE.) Starts tracking propertychange events on the passed-in element
  * and override the value property so that we can distinguish user events from
  * value changes in JS.
@@ -60,7 +78,7 @@ var startWatching = function(target) {
  * element, if any exists.
  */
 var stopWatching = function() {
-    if (!activeElement) return;
+    if (!activeElement) { return; }
 
     // delete restores the original property definition
     delete activeElement.value;
@@ -69,20 +87,6 @@ var stopWatching = function() {
     activeElement = null;
     activeElementValue = null;
     activeElementValueProp = null;
-};
-
-/**
- * (For old IE.) Handles a propertychange event, sending a textChange event if
- * the value of the active element has changed.
- */
-var handlePropertyChange = function(nativeEvent) {
-    if (nativeEvent.propertyName !== "value") return;
-
-    var value = nativeEvent.srcElement.value;
-    if (value === activeElementValue) return;
-    activeElementValue = value;
-
-    $(activeElement).trigger("textchange");
 };
 
 if (isInputSupported) {
@@ -142,4 +146,4 @@ if (isInputSupported) {
         });
 }
 
-})(jQuery);
+}(jQuery));

--- a/jquery.splendid.textchange.js
+++ b/jquery.splendid.textchange.js
@@ -41,10 +41,9 @@
         // Other input methods (e.g., paste) seem to fire selectionchange
         // normally.
 
-    /**
-     * (For old IE.) Return true if the specified element can generate
-     * change notifications (i.e. can be used by users to input values).
-     */
+
+    // Return true if the specified element can generate
+    // change notifications (i.e. can be used by users to input values).
     function hasInputCapabilities(elem) {
         // The HTML5 spec lists many more types than `text` and `password` on
         // which the input event is triggered but none of them exist in IE 8 or
@@ -56,9 +55,8 @@
         );
     }
 
-    /**
-     * (For old IE.)
-     */
+
+    // Update the specified target so that we can track its value changes.
     function installValueExtensionsOn(target) {
         if (!target.valueExtensions) { // we haven't installed extensions yet (or "target" is not an input-capable element)
             if (hasInputCapabilities(target)) {
@@ -94,11 +92,8 @@
         }
     }
 
-    /**
-     * (For old IE.) For each queued element: if value of the element is
-     * different from the current value, update the current value and trigger
-     * "textchange" event on that element.
-     */
+
+    // Fire "textchange" event for each queued element whose value changed.
     function processNotificationQueue() {
         // remember the current notification queue (for processing)
         // + create a new queue so that if "textchange" event handlers
@@ -118,10 +113,9 @@
         }
     }
 
-    /**
-     * (For old IE.) If activeElement has not yet been queued for
-     * notification, queue it now.
-     */
+
+    // If target element of the specified event has not yet been
+    // queued for notification, queue it now.
     queueActiveElementForNotification = function queueActiveElementForNotification(e) {
         var target = e.target;
         installValueExtensionsOn(target);
@@ -143,25 +137,22 @@
         }
     };
 
-    /**
-     * (For old IE.) Marks the specified target element as currently
-     * tracked element and adds event listeners to it.
-     */
+
+    // Mark the specified target element as "active" and add event listeners to it.
     function startWatching(target) {
         activeElement = target;
         $(activeElement).on(watchedEvents, queueActiveElementForNotification);
     }
 
-    /**
-     * (For old IE.) Removes the event listeners from the currently tracked
-     * element and sets currently tracked element to null.
-     */
+
+    // Remove the event listeners from the "active" element and set "active" to null.
     function stopWatching() {
         if (activeElement) {
             $(activeElement).off(watchedEvents, queueActiveElementForNotification);
             activeElement = null;
         }
     }
+
 
     $(document)
         .on("focusin", function (e) {


### PR DESCRIPTION
- Group all updates to a target element together and defer `textchange` event triggering to the next tick using `setTimeout(..., 0)`
  - Fixes cursor reset in `textarea` when `textchange` event handler sets a `value`
  - Reduces number of `textchange` notifications during drag & drop operations
- Support drag & drop between input controls and dropping text from outside the browser
  - When text is moved from one element to another via drag & drop, one `textchange` event for each element is fired
- Reduce use of `activeElement`
- Permanently override `value`, not just when element has focus
- Add version information (currently random choice of `1.2 alpha1`)
- Tested in IE8 on Windows XP, IE9 on Win7 (both using ModernIE VM), simulated IE8 and IE9 mode in IE11 on Windows 8.1, Chrome and Firefox

Known issues:
- A `textchange` event is fired the first time an element is focused (even though focusing did not change the value)
